### PR TITLE
Add script references instead of inserting contents

### DIFF
--- a/includes/qunit-page.tpl
+++ b/includes/qunit-page.tpl
@@ -3,22 +3,16 @@
 <head>
   <meta charset="utf-8">
   <title><%= title %></title>
-  <style>
   <%= style %>
-  </style>
   <script>
   <%= script.header %>
   </script>
   <!-- Libs -->
   <% _.each(script.includes, function(includeTag) { %> <%= includeTag %> <% }); %>
   <!-- QUnit -->
-  <script>
   <%= script.qunit %>
-  </script>
   <!-- QUnit Bridge -->
-  <script>
   <%= script.qunitBridge %>
-  </script>
   <!-- Tests -->
   <% _.each(script.tests, function(testTag) { %> <%= testTag %> <% }); %>
 </head>

--- a/test/PageBuilder_spec.coffee
+++ b/test/PageBuilder_spec.coffee
@@ -112,6 +112,8 @@ describe "PageBuilder", ->
 
 			should.exist pageContents, "pageContents"
 
+			console.log pageUrl
+
 			fs.exists pageUrl, (exists) ->
 				exists.should.equal true
 

--- a/test/PageBuilder_spec.coffee
+++ b/test/PageBuilder_spec.coffee
@@ -112,8 +112,6 @@ describe "PageBuilder", ->
 
 			should.exist pageContents, "pageContents"
 
-			console.log pageUrl
-
 			fs.exists pageUrl, (exists) ->
 				exists.should.equal true
 


### PR DESCRIPTION
This is a change designed to help speed up the running of the qunit tests.  Instead of putting all the code in the page we add script references and copy each file to a location relative to qunit html file that is created in a temp directory.
