### PR TITLE
Allow a new argument, "build", to be passed through a task to get just the output of the built files.

### DIFF
--- a/tasks/lib/QUnitServerlessTask.js
+++ b/tasks/lib/QUnitServerlessTask.js
@@ -23,14 +23,16 @@ _.extend(QUnitServerlessTask.prototype, {
 			"qunit-filter": grunt.option("qunit-filter") 
 		});
 	},
-
+	build: function(callback) {
+		var pageBuilder = new PageBuilder(this.options);
+		pageBuilder.build(callback);
+	},
 	run: function() {
 		var self = this,
-			done = this.async(),
-			pageBuilder = new PageBuilder(this.options);
+			done = this.async();
 
 		// Build the html page up and save it to a temp location, return a url to temp file.
-		pageBuilder.build(function(err, fileCreatedPath) {
+		self.build(function(err, fileCreatedPath) {
 			if(err) {
 				grunt.fatal(err.message);
 				return done();
@@ -63,10 +65,22 @@ QUnitServerlessTask.registerWithGrunt = function(grunt) {
 
 	var phantomjs = require('grunt-lib-phantomjs').init(grunt);
 
-	grunt.registerMultiTask("qunit-serverless", "Builds up an HTML page and runs it with PhantomJS", function() {
-		var task = new QUnitServerlessTask(this, phantomjs);
-
-		task.run();
+	grunt.registerMultiTask("qunit-serverless", "Builds up an HTML page and runs it with PhantomJS", function(build) {
+		var task = new QUnitServerlessTask(this, phantomjs), done;
+		// handle the case where we only want to build the code
+		if( arguments.length === 0) {
+			task.run();
+		} else if( build === "build" ) {
+			done = this.async();
+			task.build(function(err, fileCreatePath){
+				if( err ) {
+					grunt.fatal( err.message );
+					return done();
+				}
+				grunt.log.writeln(fileCreatePath);
+				done();	
+			});
+		}
 	});
 };
 


### PR DESCRIPTION
This allows built files to be handled differently than just running phantom, and even moved to a more convenient spot. 

Here is an example SH file that would work with this process (where "all" is the task options in the Gruntfile.js).

```
'''
#!/bin/sh
myvar=$(echo $(grunt qunit-serverless:all:build) | awk '{print $5}')
echo $myvar
''''
```
