### PR TITLE
Using this.failedTestCount to number the failing tests correctly

### DIFF
--- a/tasks/lib/reporter/spec.js
+++ b/tasks/lib/reporter/spec.js
@@ -109,7 +109,7 @@ _.extend(SpecReporter.prototype, {
 		}
 
 		if(!testPassed) {
-			this._failedTestMsgs.push("1) " + this._currModule);
+			this._failedTestMsgs.push( ( this._failedTestCount+1 )+") " + this._currModule);
 			this._failedTestMsgs.push(msg);
 		}
 


### PR DESCRIPTION
This is a very simple fix of the issue #9 using the pre-existing, in-scope variable `this._failedTestCount`.

IHTH
